### PR TITLE
Fix#6: Add fallback for blog post sharing with clipboard and user feedback

### DIFF
--- a/components/BlogList.tsx
+++ b/components/BlogList.tsx
@@ -31,22 +31,23 @@ export function BlogList({ posts }: { posts: Blog[] }) {
         )
 
     const handleShare = async ({ post }: { post: Blog }) => {
-        if (navigator.share) {
-            try {
+        try {
+            if (navigator.share) {
                 await navigator.share({
                     title: post.title,
                     text: `Check out this article: ${post.title} by ${post.author}`,
                     url: post.link,
                 })
-            } catch (error) {
-                console.error('Error sharing:', error)
-                toast.error('Failed to share the link.')
-            } finally {
-                navigator.clipboard.writeText(post.link)
+                toast.success('Post shared successfully!')
+            } else if (navigator.clipboard && navigator.clipboard.writeText) {
+                await navigator.clipboard.writeText(post.link)
+                toast.success('Copied the link to clipboard!')
+            } else {
+                toast.error('Clipboard API not supported on this device.')
             }
-        } else {
-            await navigator.clipboard.writeText(post.link)
-            toast.success('Copied the link to clipboard!')
+        } catch (error) {
+            console.error('Error sharing:', error)
+            toast.error('Failed to share the link.')
         }
     }
 

--- a/components/digest/share-button.tsx
+++ b/components/digest/share-button.tsx
@@ -37,11 +37,11 @@ export function ShareButton({
                     toast.error('Sharing was cancelled.')
                 }
             }
-        } catch (err: any) {
+        } catch (err: unknown) {
             console.error('Sharing failed:', err)
 
             // Handle cancel case separately
-            if (err.name === 'AbortError') {
+            if (err instanceof DOMException && err.name === 'AbortError') {
                 toast.info('Sharing was cancelled.')
             } else {
                 toast.error('Failed to copy link automatically.')

--- a/components/digest/share-button.tsx
+++ b/components/digest/share-button.tsx
@@ -1,8 +1,8 @@
 'use client'
 
-import { useState } from 'react'
 import { Button } from '@/components/ui/button'
-import { Share2, Check } from 'lucide-react'
+import { Share2 } from 'lucide-react'
+import { toast, Toaster } from 'sonner'
 
 interface ShareButtonProps {
     title?: string
@@ -13,37 +13,55 @@ export function ShareButton({
     title = 'Share this post',
     className,
 }: ShareButtonProps) {
-    const [copied, setCopied] = useState(false)
-
     const handleShare = async () => {
         try {
-            await navigator.clipboard.writeText(window.location.href)
-            setCopied(true)
-            setTimeout(() => setCopied(false), 2000)
-        } catch (err) {
-            console.error('Failed to copy link:', err)
+            if (navigator.share) {
+                await navigator.share({
+                    title: document.title,
+                    url: window.location.href,
+                })
+                toast.success('Post shared successfully!')
+            } else if (navigator.clipboard && navigator.clipboard.writeText) {
+                await navigator.clipboard.writeText(window.location.href)
+                toast.success('Link copied to clipboard!')
+            } else {
+                const link = window.location.href
+                const userConfirmed = window.confirm(
+                    `Your device does not support automatic copying. Please copy the link manually:\n\n${link}`
+                )
+                if (userConfirmed) {
+                    toast.success(
+                        'Please paste the link where you want to share it.'
+                    )
+                } else {
+                    toast.error('Sharing was cancelled.')
+                }
+            }
+        } catch (err: any) {
+            console.error('Sharing failed:', err)
+
+            // Handle cancel case separately
+            if (err.name === 'AbortError') {
+                toast.info('Sharing was cancelled.')
+            } else {
+                toast.error('Failed to copy link automatically.')
+            }
         }
     }
 
     return (
-        <Button
-            variant="outline"
-            size="sm"
-            onClick={handleShare}
-            className={className}
-            aria-label={copied ? 'Link copied!' : title}
-        >
-            {copied ? (
-                <div className="text-primary flex items-center justify-center gap-2">
-                    <Check className="h-4 w-4" />
-                    Copied!
-                </div>
-            ) : (
-                <>
-                    <Share2 className="mr-2 h-4 w-4" />
-                    Share
-                </>
-            )}
-        </Button>
+        <>
+            <Toaster richColors position="top-right" />
+            <Button
+                variant="outline"
+                size="sm"
+                onClick={handleShare}
+                className={className}
+                aria-label={title}
+            >
+                <Share2 className="mr-2 h-4 w-4" />
+                Share
+            </Button>
+        </>
     )
 }


### PR DESCRIPTION
This PR improves the sharing functionality to handle cases where navigator.share or clipboard permissions are not available.

Changes

Wrapped sharing logic in try/catch to prevent crashes

Added fallback to copy blog post link to clipboard

Implemented manual copy option if clipboard API is unavailable

Displayed user feedback via toast/snackbar for success and failure states

Acceptance Criteria

✅ No crashes when sharing is unsupported

✅ User always sees a success or failure message

✅ Link is shared or copied reliably across devices
<img width="468" height="92" alt="image" src="https://github.com/user-attachments/assets/2d10fe2f-3b69-46c5-a5a4-b658003a366d" />
